### PR TITLE
Improve notes site: tags, search, RSS, and reading polish

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,10 @@
         "@astrojs/sitemap": "^3.1.1",
         "astro": "^4.4.6",
         "typescript": "^5.3.3"
+      },
+      "devDependencies": {
+        "@rollup/rollup-linux-x64-gnu": "4.6.1",
+        "pagefind": "^1.5.2"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -623,6 +627,130 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@pagefind/darwin-arm64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/darwin-arm64/-/darwin-arm64-1.5.2.tgz",
+      "integrity": "sha512-MXpI+7HsAdPkvJ0gk9xj9g541BCqBZOBbdwj9g6lB5LCj6kSV6nqDSjzcAJwvOsfu0fjwvC8hQU+ecfhp+MpiQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@pagefind/darwin-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/darwin-x64/-/darwin-x64-1.5.2.tgz",
+      "integrity": "sha512-IojxFWMEJe0RQ7PQ3KXQsPIImNsbpPYpoZ+QUDrL8fAl/O27IX+LVLs74/UzEZy5uA2LD8Nz1AiwKr72vrkZQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@pagefind/freebsd-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/freebsd-x64/-/freebsd-x64-1.5.2.tgz",
+      "integrity": "sha512-7EVzo9+0w+2cbe671BtMj10UlNo83I+HrLVLfRxO731svHRJKUfJ/mo05gU14pe9PCfpKNQT8FS3Xc/oDN6pOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@pagefind/linux-arm64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/linux-arm64/-/linux-arm64-1.5.2.tgz",
+      "integrity": "sha512-Ovt9+K35sqzn8H3ZMXGwls4TD/wMJuvRtShHIsmUQREmaxjrDEX7gHckRCrwYJ4XE1H1p6HkLz3wukrAnsfXQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@pagefind/linux-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/linux-x64/-/linux-x64-1.5.2.tgz",
+      "integrity": "sha512-V+tFqHKXhQKq/WqPBD67AFy7scn1/aZID00ws4fSDd+1daSi5UHR9VVlRrOUYKxn3VuFQYRD7lYXdZK1WED1YA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@pagefind/windows-arm64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/windows-arm64/-/windows-arm64-1.5.2.tgz",
+      "integrity": "sha512-hN9Nh90fNW61nNRCW9ZyQrAj/mD0eRvmJ8NlTUzkbuW8kIzGJUi3cxjFkEcMZ5h/8FsKWD/VcouZl4yo1F7B6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@pagefind/windows-x64": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@pagefind/windows-x64/-/windows-x64-1.5.2.tgz",
+      "integrity": "sha512-Fa2Iyw7kaDRzGMfNYNUXNW2zbL5FQVDgSOcbDHdzBrDEdpqOqg8TcZ68F22ol6NJ9IGzvUdmeyZypLW5dyhqsg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.57.1.tgz",
+      "integrity": "sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.57.1.tgz",
+      "integrity": "sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.57.1",
       "cpu": [
@@ -632,6 +760,292 @@
       "optional": true,
       "os": [
         "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.57.1.tgz",
+      "integrity": "sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.57.1.tgz",
+      "integrity": "sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.57.1.tgz",
+      "integrity": "sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.57.1.tgz",
+      "integrity": "sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.57.1.tgz",
+      "integrity": "sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.57.1.tgz",
+      "integrity": "sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.57.1.tgz",
+      "integrity": "sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.57.1.tgz",
+      "integrity": "sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.57.1.tgz",
+      "integrity": "sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.57.1.tgz",
+      "integrity": "sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.57.1.tgz",
+      "integrity": "sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.57.1.tgz",
+      "integrity": "sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.57.1.tgz",
+      "integrity": "sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.57.1.tgz",
+      "integrity": "sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.6.1.tgz",
+      "integrity": "sha512-DNGZvZDO5YF7jN5fX8ZqmGLjZEXIJRdJEdTFMhiyXqyXubBa0WVLDWSNlQ5JR2PNgDbEV1VQowhVRUh+74D+RA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.57.1.tgz",
+      "integrity": "sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.57.1.tgz",
+      "integrity": "sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.57.1.tgz",
+      "integrity": "sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.57.1.tgz",
+      "integrity": "sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.57.1.tgz",
+      "integrity": "sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.57.1.tgz",
+      "integrity": "sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.57.1.tgz",
+      "integrity": "sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ]
     },
     "node_modules/@types/acorn": {
@@ -4033,6 +4447,25 @@
         "node": ">=6"
       }
     },
+    "node_modules/pagefind": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/pagefind/-/pagefind-1.5.2.tgz",
+      "integrity": "sha512-XTUaK0hXMCu2jszWE584JGQT7y284TmMV9l/HX3rnG5uo3rHI/uHU56XTyyyPFjeWEBxECbAi0CaFDJOONtG0Q==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "pagefind": "lib/runner/bin.cjs"
+      },
+      "optionalDependencies": {
+        "@pagefind/darwin-arm64": "1.5.2",
+        "@pagefind/darwin-x64": "1.5.2",
+        "@pagefind/freebsd-x64": "1.5.2",
+        "@pagefind/linux-arm64": "1.5.2",
+        "@pagefind/linux-x64": "1.5.2",
+        "@pagefind/windows-arm64": "1.5.2",
+        "@pagefind/windows-x64": "1.5.2"
+      }
+    },
     "node_modules/parse-entities": {
       "version": "4.0.1",
       "license": "MIT",
@@ -4994,6 +5427,19 @@
         "@rollup/rollup-win32-x64-msvc": "4.57.1",
         "fsevents": "~2.3.2"
       }
+    },
+    "node_modules/rollup/node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.57.1.tgz",
+      "integrity": "sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",
-    "build": "astro check && astro build",
+    "build": "astro check && astro build && pagefind --site dist",
     "preview": "astro preview",
     "astro": "astro"
   },
@@ -18,6 +18,7 @@
     "typescript": "^5.3.3"
   },
   "devDependencies": {
-    "@rollup/rollup-linux-x64-gnu": "4.6.1"
+    "@rollup/rollup-linux-x64-gnu": "4.6.1",
+    "pagefind": "^1.5.2"
   }
 }

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -20,6 +20,14 @@ const { title, description, image = "/blog-placeholder-1.jpg" } = Astro.props;
 <link rel="icon" type="image/svg+xml" href="/favicon.ico" />
 <meta name="generator" content={Astro.generator} />
 
+<!-- RSS feed -->
+<link
+  rel="alternate"
+  type="application/rss+xml"
+  title="Mario Yordanov — Notes"
+  href={new URL("rss.xml", Astro.site)}
+/>
+
 <!-- Font preloads -->
 <link
   rel="preload"

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -2,6 +2,7 @@
 // Import the global.css file here so that it is included on
 // all pages through the use of the <BaseHead /> component.
 import "../styles/global.css";
+import { ViewTransitions } from "astro:transitions";
 
 interface Props {
   title: string;
@@ -67,7 +68,6 @@ const { title, description, image = "/blog-placeholder-1.jpg" } = Astro.props;
 
 <!-- Canonical URL -->
 <link rel="canonical" href={canonicalURL} />
-
 <!-- Primary Meta Tags -->
 <title>{title}</title>
 <meta name="title" content={title} />
@@ -95,3 +95,6 @@ const { title, description, image = "/blog-placeholder-1.jpg" } = Astro.props;
     document.documentElement.setAttribute('data-theme', theme);
   })();
 </script>
+
+<!-- Animated page navigation -->
+<ViewTransitions />

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -4,6 +4,9 @@ const today = new Date();
 
 <footer>
   &copy; {today.getFullYear()} Mario Yordanov. All rights reserved.
+  <div class="footer-links">
+    <a href="/rss.xml">RSS</a>
+  </div>
   <div class="social-links">
     <a href="https://www.linkedin.com/in/mariovyordanov/" target="_blank">
       <span class="sr-only">Follow Mario on Linkedin</span>
@@ -48,6 +51,14 @@ const today = new Date();
     justify-content: center;
     gap: 1em;
     margin-top: 1em;
+  }
+  .footer-links {
+    margin-top: 0.5em;
+    font-family: "Roboto", sans-serif;
+    font-size: 0.85rem;
+  }
+  .footer-links a {
+    color: rgb(var(--gray));
   }
   .social-links a {
     text-decoration: none;

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -8,6 +8,7 @@ import ThemeToggle from "./ThemeToggle.astro";
     <div class="internal-links">
       <HeaderLink href="/">Home</HeaderLink>
       <HeaderLink href="/notes">Notes</HeaderLink>
+      <HeaderLink href="/tags">Tags</HeaderLink>
       <HeaderLink href="/playground">Playground</HeaderLink>
       <ThemeToggle />
     </div>

--- a/src/components/NoteStatus.astro
+++ b/src/components/NoteStatus.astro
@@ -1,0 +1,35 @@
+---
+interface Props {
+  status: "seedling" | "growing" | "evergreen";
+}
+
+const { status } = Astro.props;
+
+const meta = {
+  seedling: { label: "Seedling", icon: "🌱", hint: "A rough, early note" },
+  growing: { label: "Growing", icon: "🌿", hint: "Being developed" },
+  evergreen: { label: "Evergreen", icon: "🌳", hint: "Fairly settled" },
+} as const;
+
+const { label, icon, hint } = meta[status];
+---
+
+<span class:list={["status", status]} title={hint}>
+  <span aria-hidden="true">{icon}</span>{label}
+</span>
+
+<style>
+  .status {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35em;
+    font-family: "Roboto", sans-serif;
+    font-size: 0.75rem;
+    line-height: 1;
+    padding: 0.35em 0.6em;
+    border-radius: 999px;
+    color: rgb(var(--gray));
+    border: 1px solid var(--border-color);
+    white-space: nowrap;
+  }
+</style>

--- a/src/components/PostCard.astro
+++ b/src/components/PostCard.astro
@@ -1,43 +1,74 @@
 ---
 import FormattedDate from "./FormattedDate.astro";
+import Tag from "./Tag.astro";
+import NoteStatus from "./NoteStatus.astro";
 
-const { title, pubDate, description, slug } = Astro.props;
+const { title, pubDate, description, slug, tags = [], status } = Astro.props;
 ---
 
-<a href={`/notes/${slug}/`}>
-  <p class="date">
-    <FormattedDate date={pubDate} />
-  </p>
-  <h5 class="title">{title}</h5>
+<a href={`/notes/${slug}/`} class="card">
+  <div class="meta">
+    <p class="date">
+      <FormattedDate date={pubDate} />
+    </p>
+    {status && <NoteStatus status={status} />}
+  </div>
+  <h2 class="title">{title}</h2>
   <p class="description">
     {description}
   </p>
+  {
+    tags.length > 0 && (
+      <div class="tags">
+        {tags.map((tag: string) => (
+          <Tag tag={tag} interactive={false} />
+        ))}
+      </div>
+    )
+  }
 </a>
 <style>
-  * {
-    text-decoration: none;
-    transition: 0.2s ease;
-  }
-  a {
+  .card {
     display: block;
     border: 1px solid var(--border-color);
     padding: 1.5rem;
-    border-radius: 0.5rem;
+    border-radius: 0.75rem;
+    text-decoration: none;
+    transition: 0.2s ease;
+    background: var(--bg-primary);
+  }
+  .card:hover {
+    border-color: var(--accent);
+    transform: translateY(-2px);
+    box-shadow: 0 6px 20px rgba(var(--gray), 20%);
+  }
+  .meta {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
   }
   .title {
-    margin: 0.3rem 0;
-    line-height: 1;
+    margin: 0.4rem 0;
+    line-height: 1.15;
+    font-size: 1.35rem;
+  }
+  .card:hover .title {
+    color: var(--accent);
   }
   .date {
     margin: 0;
     color: rgb(var(--gray));
+    font-size: 0.85rem;
   }
   .description {
     color: rgb(var(--gray));
-    margin: 0;
+    margin: 0.5rem 0 0 0;
   }
-  a:hover h4,
-  a:hover .date .description {
-    color: rgb(var(--accent));
+  .tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+    margin-top: 1rem;
   }
 </style>

--- a/src/components/PostCard.astro
+++ b/src/components/PostCard.astro
@@ -6,7 +6,7 @@ import NoteStatus from "./NoteStatus.astro";
 const { title, pubDate, description, slug, tags = [], status } = Astro.props;
 ---
 
-<a href={`/notes/${slug}/`} class="card">
+<a href={`/notes/${slug}/`} class="card" data-tilt>
   <div class="meta">
     <p class="date">
       <FormattedDate date={pubDate} />
@@ -34,13 +34,14 @@ const { title, pubDate, description, slug, tags = [], status } = Astro.props;
     padding: 1.5rem;
     border-radius: 0.75rem;
     text-decoration: none;
-    transition: 0.2s ease;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.1s ease;
     background: var(--bg-primary);
+    transform-style: preserve-3d;
+    will-change: transform;
   }
   .card:hover {
     border-color: var(--accent);
-    transform: translateY(-2px);
-    box-shadow: 0 6px 20px rgba(var(--gray), 20%);
+    box-shadow: 0 10px 30px rgba(var(--gray), 22%);
   }
   .meta {
     display: flex;
@@ -72,3 +73,30 @@ const { title, pubDate, description, slug, tags = [], status } = Astro.props;
     margin-top: 1rem;
   }
 </style>
+
+<script>
+  function initTilt() {
+    const reduce = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    const fine = window.matchMedia("(pointer: fine)").matches;
+    if (reduce || !fine) return;
+
+    const MAX = 6; // degrees
+    document.querySelectorAll<HTMLElement>("[data-tilt]").forEach((card) => {
+      if (card.dataset.tiltBound) return;
+      card.dataset.tiltBound = "true";
+
+      card.addEventListener("pointermove", (e) => {
+        const r = card.getBoundingClientRect();
+        const px = (e.clientX - r.left) / r.width - 0.5;
+        const py = (e.clientY - r.top) / r.height - 0.5;
+        card.style.transform = `perspective(700px) rotateY(${px * MAX}deg) rotateX(${-py * MAX}deg) translateY(-2px)`;
+      });
+      card.addEventListener("pointerleave", () => {
+        card.style.transform = "";
+      });
+    });
+  }
+
+  initTilt();
+  document.addEventListener("astro:page-load", initTilt);
+</script>

--- a/src/components/Tag.astro
+++ b/src/components/Tag.astro
@@ -1,0 +1,33 @@
+---
+interface Props {
+  tag: string;
+  interactive?: boolean;
+}
+
+const { tag, interactive = true } = Astro.props;
+const Element = interactive ? "a" : "span";
+const href = interactive ? `/tags/${tag}/` : undefined;
+---
+
+<Element class="tag" href={href}>#{tag}</Element>
+
+<style>
+  .tag {
+    display: inline-block;
+    font-family: "Roboto", sans-serif;
+    font-size: 0.75rem;
+    line-height: 1;
+    padding: 0.35em 0.6em;
+    border: 1px solid var(--border-color);
+    border-radius: 999px;
+    color: rgb(var(--gray));
+    text-decoration: none;
+    background: var(--bg-secondary);
+    transition: 0.2s ease;
+    white-space: nowrap;
+  }
+  a.tag:hover {
+    color: var(--accent);
+    border-color: var(--accent);
+  }
+</style>

--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -70,12 +70,17 @@
     localStorage.setItem('theme', newTheme);
   }
 
-  // Initialize theme on page load
+  // Initialize theme on first load
   initTheme();
 
-  // Add click handler
-  document.getElementById('theme-toggle')?.addEventListener('click', toggleTheme);
+  // Bind the toggle button (rebinds after each view transition swap)
+  function bindToggle() {
+    const btn = document.getElementById('theme-toggle');
+    btn?.addEventListener('click', toggleTheme);
+  }
+  bindToggle();
+  document.addEventListener('astro:page-load', bindToggle);
 
-  // Re-initialize after navigation (for Astro view transitions)
+  // Re-apply saved theme after navigation
   document.addEventListener('astro:after-swap', initTheme);
 </script>

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,5 +1,6 @@
 // Place any global data in this file.
 // You can import this data from anywhere in your site by using the `import` keyword.
 
-export const SITE_TITLE = "Web Developer | Notes | Mario Yordanov";
-export const SITE_DESCRIPTION = "Notes on Web Development by Mario Yordanov";
+export const SITE_TITLE = "Mario Yordanov — Notes";
+export const SITE_DESCRIPTION =
+  "Notes on web development, architecture, and whatever I'm thinking through — mostly written for myself.";

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -10,6 +10,10 @@ const notes = defineCollection({
     pubDate: z.coerce.date(),
     updatedDate: z.coerce.date().optional(),
     heroImage: z.string().optional(),
+    tags: z.array(z.string()).default([]),
+    status: z
+      .enum(["seedling", "growing", "evergreen"])
+      .default("evergreen"),
   }),
 });
 

--- a/src/content/notes/domain-driven-design-angular.md
+++ b/src/content/notes/domain-driven-design-angular.md
@@ -2,6 +2,8 @@
 title: "Domain-Driven Design for Angular and Frontend Developers"
 description: "How DDD and the Angular Styleguide help teams organize frontend code around business concepts, keep components focused, and make domain logic explicit."
 pubDate: "May 2 2026"
+tags: ["frontend", "architecture", "angular"]
+status: "evergreen"
 ---
 
 *How DDD and the Angular Styleguide help teams organize frontend code around business concepts, keep components focused, and make domain logic explicit.*

--- a/src/content/notes/dynamic-import.md
+++ b/src/content/notes/dynamic-import.md
@@ -2,6 +2,8 @@
 title: "Dynamic Import in JavaScript"
 description: "Using dynamic import() for lazy-loading in JavaScript."
 pubDate: "January 13 2026"
+tags: ["javascript", "frontend"]
+status: "evergreen"
 ---
 
 Modern JavaScript applications can greatly benefit from dynamic `import()`, a feature that allows you to load modules only when needed. While static import works well for core dependencies, dynamic `import()` is perfect for improving performance and reducing the initial load time of large apps.

--- a/src/content/notes/intl.md
+++ b/src/content/notes/intl.md
@@ -2,6 +2,8 @@
 title: "JavaScript Intl for Localization"
 description: "Localizing dates, numbers, and lists."
 pubDate: "March 18 2026"
+tags: ["javascript", "frontend"]
+status: "evergreen"
 ---
 
 JavaScript's `Intl` namespace (ECMA-402) helps you localize your app, no extra libraries required. It formats numbers, dates, lists, and

--- a/src/content/notes/notes-microservices.md
+++ b/src/content/notes/notes-microservices.md
@@ -2,6 +2,8 @@
 title: "Microservice Architecture"
 description: "Key takeaways from reading Fowler & Lewis on Microservice Architecture."
 pubDate: "February 8 2026"
+tags: ["architecture", "backend"]
+status: "growing"
 ---
 
 👉 Key takeaways from 

--- a/src/content/notes/osi-model.md
+++ b/src/content/notes/osi-model.md
@@ -2,6 +2,8 @@
 title: "Layer 4 vs Layer 7 Load Balancing (and the OSI Model)"
 description: "When cloud docs (like Azure's) talk about Layer 4 or Layer 7, they're referring to the OSI model"
 pubDate: "April 10 2026"
+tags: ["networking", "architecture"]
+status: "evergreen"
 ---
 
 When cloud docs (like Azure's) talk about *Layer 4* or *Layer 7*,

--- a/src/content/notes/system-req-and-arch-drivers-article.md
+++ b/src/content/notes/system-req-and-arch-drivers-article.md
@@ -2,6 +2,8 @@
 title: "System Requirements and Architectural Drivers"
 description: "Laying the Groundwork for Real-World Systems"
 pubDate: "March 22 2026"
+tags: ["architecture"]
+status: "growing"
 ---
 
 Before picking a framework, spinning up a database, or arguing about microservices vs. monoliths, there's a more fundamental question to answer: **what are we actually building, and under what conditions?**

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -175,24 +175,54 @@ const {
 </html>
 
 <script>
-  // Add a copy button to every code block.
-  document.querySelectorAll("article pre").forEach((pre) => {
-    const button = document.createElement("button");
-    button.className = "copy-code";
-    button.type = "button";
-    button.textContent = "Copy";
-    pre.appendChild(button);
-    button.addEventListener("click", async () => {
-      const code = pre.querySelector("code")?.textContent ?? pre.textContent ?? "";
-      try {
-        await navigator.clipboard.writeText(code);
-        button.textContent = "Copied!";
-        setTimeout(() => (button.textContent = "Copy"), 1500);
-      } catch {
-        button.textContent = "Failed";
-      }
+  // Add a copy button to every code block (re-runs after view transitions).
+  function addCopyButtons() {
+    document.querySelectorAll("article pre").forEach((pre) => {
+      if (pre.querySelector(".copy-code")) return;
+      const button = document.createElement("button");
+      button.className = "copy-code";
+      button.type = "button";
+      button.textContent = "Copy";
+      pre.appendChild(button);
+      button.addEventListener("click", async () => {
+        const code = pre.querySelector("code")?.textContent ?? pre.textContent ?? "";
+        try {
+          await navigator.clipboard.writeText(code);
+          button.textContent = "Copied!";
+          spawnCoins(button);
+          setTimeout(() => (button.textContent = "Copy"), 1500);
+        } catch {
+          button.textContent = "Failed";
+        }
+      });
     });
-  });
+  }
+
+  // Little coin burst for delight when copying.
+  function spawnCoins(anchor: HTMLElement) {
+    const rect = anchor.getBoundingClientRect();
+    const originX = rect.left + rect.width / 2;
+    const originY = rect.top + rect.height / 2;
+    const count = 10;
+    for (let i = 0; i < count; i++) {
+      const coin = document.createElement("span");
+      coin.className = "coin";
+      coin.textContent = "🪙";
+      coin.style.left = `${originX}px`;
+      coin.style.top = `${originY}px`;
+      const angle = Math.PI * (0.75 + (0.5 * i) / count) + (Math.random() - 0.5);
+      const distance = 40 + Math.random() * 60;
+      const dx = Math.cos(angle) * distance;
+      const dy = -Math.abs(Math.sin(angle) * distance) - 20;
+      coin.style.setProperty("--dx", `${dx}px`);
+      coin.style.setProperty("--dy", `${dy}px`);
+      document.body.appendChild(coin);
+      coin.addEventListener("animationend", () => coin.remove());
+    }
+  }
+
+  addCopyButtons();
+  document.addEventListener("astro:page-load", addCopyButtons);
 </script>
 
 <style is:global>
@@ -220,5 +250,29 @@ const {
   article pre .copy-code:hover {
     border-color: var(--accent);
     color: var(--accent);
+  }
+  .coin {
+    position: fixed;
+    z-index: 9999;
+    pointer-events: none;
+    font-size: 1rem;
+    transform: translate(-50%, -50%);
+    animation: coin-burst 0.7s ease-out forwards;
+  }
+  @keyframes coin-burst {
+    0% {
+      opacity: 1;
+      transform: translate(-50%, -50%) translate(0, 0) scale(0.6) rotate(0deg);
+    }
+    100% {
+      opacity: 0;
+      transform: translate(-50%, -50%) translate(var(--dx), var(--dy)) scale(1.1)
+        rotate(180deg);
+    }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .coin {
+      display: none;
+    }
   }
 </style>

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -4,15 +4,32 @@ import BaseHead from "../components/BaseHead.astro";
 import Header from "../components/Header.astro";
 import Footer from "../components/Footer.astro";
 import FormattedDate from "../components/FormattedDate.astro";
+import Tag from "../components/Tag.astro";
+import NoteStatus from "../components/NoteStatus.astro";
 
-type Props = CollectionEntry<"notes">["data"];
+type Props = CollectionEntry<"notes">["data"] & {
+  readingTime?: number;
+  prev?: { slug: string; title: string } | null;
+  next?: { slug: string; title: string } | null;
+};
 
-const { title, description, pubDate, updatedDate } = Astro.props;
+const {
+  title,
+  description,
+  pubDate,
+  updatedDate,
+  heroImage,
+  tags = [],
+  status,
+  readingTime,
+  prev,
+  next,
+} = Astro.props;
 ---
 
 <html lang="en">
   <head>
-    <BaseHead title={title} description={description} />
+    <BaseHead title={title} description={description} image={heroImage} />
     <style>
       main {
         width: calc(100% - 2em);
@@ -25,20 +42,74 @@ const { title, description, pubDate, updatedDate } = Astro.props;
         margin: auto;
         padding: 1em;
       }
+      .hero {
+        width: 100%;
+        margin-bottom: 1.5em;
+        border-radius: 8px;
+      }
       .title {
         margin-bottom: 1em;
         padding: 1em 0;
         line-height: 1;
       }
       .title h1 {
-        margin: 0 0 0.5em 0;
+        margin: 0 0 0.3em 0;
       }
-      .date {
-        margin-bottom: 0.5em;
+      .meta {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 0.75rem;
+        margin-bottom: 0.75em;
         color: rgb(var(--gray));
+        font-family: "Roboto", sans-serif;
+        font-size: 0.85rem;
+      }
+      .reading-time::before {
+        content: "·";
+        margin-right: 0.75rem;
       }
       .last-updated-on {
         font-style: italic;
+      }
+      .tags {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.4rem;
+        margin-top: 0.75em;
+      }
+      .back-link {
+        display: inline-block;
+        margin-bottom: 1em;
+        color: rgb(var(--gray));
+        text-decoration: none;
+        font-family: "Roboto", sans-serif;
+        font-size: 0.9rem;
+      }
+      .back-link:hover {
+        color: var(--accent);
+      }
+      .post-nav {
+        display: flex;
+        justify-content: space-between;
+        gap: 1rem;
+        margin-top: 3rem;
+        padding-top: 1.5rem;
+        border-top: 1px solid var(--border-color);
+        font-family: "Roboto", sans-serif;
+      }
+      .post-nav a {
+        max-width: 45%;
+        text-decoration: none;
+      }
+      .post-nav .label {
+        display: block;
+        color: rgb(var(--gray));
+        font-size: 0.75rem;
+      }
+      .post-nav .next {
+        text-align: right;
+        margin-left: auto;
       }
     </style>
   </head>
@@ -48,24 +119,106 @@ const { title, description, pubDate, updatedDate } = Astro.props;
     <main>
       <article>
         <div class="prose">
+          <a href="/notes/" class="back-link">← Back to notes</a>
           <div class="title">
-            <div class="date">
+            <div class="meta">
               <FormattedDate date={pubDate} />
-              {
-                updatedDate && (
-                  <div class="last-updated-on">
-                    Last updated on <FormattedDate date={updatedDate} />
-                  </div>
-                )
-              }
+              {status && <NoteStatus status={status} />}
+              {readingTime && <span class="reading-time">{readingTime} min read</span>}
             </div>
+            {
+              updatedDate && (
+                <div class="meta last-updated-on">
+                  Last updated on <FormattedDate date={updatedDate} />
+                </div>
+              )
+            }
             <h1>Notes on... {title}</h1>
+            {
+              tags.length > 0 && (
+                <div class="tags">
+                  {tags.map((tag) => (
+                    <Tag tag={tag} />
+                  ))}
+                </div>
+              )
+            }
             <hr />
           </div>
-          <slot />
+          {heroImage && <img class="hero" src={heroImage} alt="" />}
+          <div data-pagefind-body>
+            <slot />
+          </div>
+          <nav class="post-nav">
+            {
+              prev && (
+                <a class="prev" href={`/notes/${prev.slug}/`}>
+                  <span class="label">← Previous</span>
+                  {prev.title}
+                </a>
+              )
+            }
+            {
+              next && (
+                <a class="next" href={`/notes/${next.slug}/`}>
+                  <span class="label">Next →</span>
+                  {next.title}
+                </a>
+              )
+            }
+          </nav>
         </div>
       </article>
     </main>
     <Footer />
   </body>
 </html>
+
+<script>
+  // Add a copy button to every code block.
+  document.querySelectorAll("article pre").forEach((pre) => {
+    const button = document.createElement("button");
+    button.className = "copy-code";
+    button.type = "button";
+    button.textContent = "Copy";
+    pre.appendChild(button);
+    button.addEventListener("click", async () => {
+      const code = pre.querySelector("code")?.textContent ?? pre.textContent ?? "";
+      try {
+        await navigator.clipboard.writeText(code);
+        button.textContent = "Copied!";
+        setTimeout(() => (button.textContent = "Copy"), 1500);
+      } catch {
+        button.textContent = "Failed";
+      }
+    });
+  });
+</script>
+
+<style is:global>
+  article pre {
+    position: relative;
+  }
+  article pre .copy-code {
+    position: absolute;
+    top: 0.6em;
+    right: 0.6em;
+    padding: 0.3em 0.6em;
+    font-family: "Roboto", sans-serif;
+    font-size: 0.75rem;
+    color: var(--text-primary);
+    background: var(--bg-primary);
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
+    cursor: pointer;
+    opacity: 0;
+    transition: opacity 0.2s ease;
+  }
+  article pre:hover .copy-code {
+    opacity: 0.9;
+  }
+  article pre .copy-code:hover {
+    border-color: var(--accent);
+    color: var(--accent);
+  }
+</style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -21,6 +21,10 @@ const posts = (await getCollection("notes")).sort(
     <main>
       <section>
         <h1 class="mt-2! title">Hi, I'm Mario Yordanov 👋</h1>
+        <p class="typed-line" aria-hidden="true">
+          <span class="prompt">~ $</span>
+          <span id="typed-text"></span><span class="cursor"></span>
+        </p>
         <p>
           Full stack developer with a strong focus on frontend. My main strength is in creating user interfaces with <b>Angular</b> and end-to-end testing with <b>Playwright</b>.
           I also work with <b>Node.js</b>, <b>Java</b>, and <b>Spring Boot</b> on the backend, and occasionally use <b>React</b>, <b>Next.js</b>, <b>Astro</b>, and other frameworks.
@@ -99,6 +103,38 @@ const posts = (await getCollection("notes")).sort(
           color: rgb(var(--gray));
         }
 
+        .typed-line {
+          font-family: "Roboto Mono", ui-monospace, "SF Mono", Menlo, monospace;
+          font-size: 1rem;
+          color: var(--accent);
+          margin: 0.25em 0 1em;
+          min-height: 1.6em;
+        }
+        .typed-line .prompt {
+          color: rgb(var(--gray));
+          margin-right: 0.5em;
+          user-select: none;
+        }
+        .cursor {
+          display: inline-block;
+          width: 0.6ch;
+          height: 1.1em;
+          vertical-align: text-bottom;
+          background: var(--accent);
+          margin-left: 2px;
+          animation: blink 1s steps(1) infinite;
+        }
+        @keyframes blink {
+          50% {
+            opacity: 0;
+          }
+        }
+        @media (prefers-reduced-motion: reduce) {
+          .cursor {
+            animation: none;
+          }
+        }
+
         .now-list {
           display: flex;
           flex-wrap: wrap;
@@ -141,5 +177,59 @@ const posts = (await getCollection("notes")).sort(
         }
       </style>
     </main>
+
+    <script>
+      const PHRASES = [
+        "full stack developer",
+        "angular & typescript",
+        "playwright end-to-end tests",
+        "node, java & spring boot",
+        "occasional react / astro",
+        "writing notes to think",
+      ];
+
+      function startTyping() {
+        const el = document.getElementById("typed-text");
+        if (!el || el.dataset.typing) return;
+        el.dataset.typing = "true";
+        const node = el;
+
+        const reduce = window.matchMedia(
+          "(prefers-reduced-motion: reduce)"
+        ).matches;
+        if (reduce) {
+          node.textContent = PHRASES[0];
+          return;
+        }
+
+        let phrase = 0;
+        let char = 0;
+        let deleting = false;
+
+        function tick() {
+          const current = PHRASES[phrase];
+          node.textContent = current.slice(0, char);
+
+          if (!deleting && char < current.length) {
+            char++;
+            setTimeout(tick, 55 + Math.random() * 45);
+          } else if (!deleting && char === current.length) {
+            deleting = true;
+            setTimeout(tick, 1400);
+          } else if (deleting && char > 0) {
+            char--;
+            setTimeout(tick, 30);
+          } else {
+            deleting = false;
+            phrase = (phrase + 1) % PHRASES.length;
+            setTimeout(tick, 300);
+          }
+        }
+        tick();
+      }
+
+      startTyping();
+      document.addEventListener("astro:page-load", startTyping);
+    </script>
   </body>
 </html>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -59,33 +59,33 @@ const posts = (await getCollection("notes")).sort(
         </div>
       </section>
       <hr />
-          <ul>
-            <li>Now Playing: <a href="https://www.youtube.com/watch?v=ADYppf44cTs" target="_blank">Ninja Gaiden: Ragebound</a></li>
-            <li>Now Listening: <a href="https://youtu.be/Z-VfaG9ZN_U?si=lTYT6fp7DbCQyWmT" target="_blank">Programming / Coding / Hacking music vol.18</a></li>
-            <li>Now Reading: <a href="https://www.goodreads.com/book/show/228810178-this-way-up" target="_blank">This Way Up: When Maps Go Wrong [and Why It Matters] by Mark Cooper-Jones and Jay Foreman</a></li>
-          </ul>
-        </div>
-      <!-- <section>
-        <header>
-          <h3 class="title">Latest posts</h3>
+      <ul class="now-list">
+        <li>Now Playing: <a href="https://www.youtube.com/watch?v=ADYppf44cTs" target="_blank">Ninja Gaiden: Ragebound</a></li>
+        <li>Now Listening: <a href="https://youtu.be/Z-VfaG9ZN_U?si=lTYT6fp7DbCQyWmT" target="_blank">Programming / Coding / Hacking music vol.18</a></li>
+        <li>Now Reading: <a href="https://www.goodreads.com/book/show/228810178-this-way-up" target="_blank">This Way Up: When Maps Go Wrong [and Why It Matters] by Mark Cooper-Jones and Jay Foreman</a></li>
+      </ul>
+      <section class="recent">
+        <header class="recent-header">
+          <h2 class="title">Recent notes</h2>
+          <a href="/notes/">All notes →</a>
         </header>
-        <section>
-          <ul>
-            {
-              posts.slice(0, 3).map((post) => (
-                <li>
-                  <PostCard
-                    pubDate={post.data.pubDate}
-                    title={post.data.title}
-                    description={post.data.description}
-                    slug={post.slug}
-                  />
-                </li>
-              ))
-            }
-          </ul>
-        </section>
-      </section> -->
+        <ul class="notes-list">
+          {
+            posts.slice(0, 4).map((post) => (
+              <li>
+                <PostCard
+                  pubDate={post.data.pubDate}
+                  title={post.data.title}
+                  description={post.data.description}
+                  slug={post.slug}
+                  tags={post.data.tags}
+                  status={post.data.status}
+                />
+              </li>
+            ))
+          }
+        </ul>
+      </section>
       <Footer />
       <style>
         .social-links {
@@ -98,8 +98,8 @@ const posts = (await getCollection("notes")).sort(
           text-decoration: none;
           color: rgb(var(--gray));
         }
-        
-        ul {
+
+        .now-list {
           display: flex;
           flex-wrap: wrap;
           gap: 1.5rem;
@@ -107,12 +107,35 @@ const posts = (await getCollection("notes")).sort(
           margin: 0;
           padding: 0;
         }
-        ul li {
+        .now-list li {
           width: 100%;
           text-decoration: none;
         }
+        .recent {
+          margin-top: 3rem;
+        }
+        .recent-header {
+          display: flex;
+          align-items: baseline;
+          justify-content: space-between;
+          gap: 1rem;
+        }
+        .recent-header a {
+          text-decoration: none;
+          font-family: "Roboto", sans-serif;
+          font-size: 0.9rem;
+          white-space: nowrap;
+        }
+        .notes-list {
+          display: flex;
+          flex-direction: column;
+          gap: 1.5rem;
+          list-style-type: none;
+          margin: 1.5rem 0 0 0;
+          padding: 0;
+        }
         @media (max-width: 720px) {
-          ul {
+          .now-list {
             gap: 0.5em;
           }
         }

--- a/src/pages/notes/[...slug].astro
+++ b/src/pages/notes/[...slug].astro
@@ -1,20 +1,36 @@
 ---
 import { type CollectionEntry, getCollection } from "astro:content";
 import BlogPost from "../../layouts/BlogPost.astro";
+import { readingTime } from "../../utils/reading-time";
 
 export async function getStaticPaths() {
-  const posts = await getCollection("notes");
-  return posts.map((post) => ({
-    params: { slug: post.slug },
-    props: post,
-  }));
+  const posts = (await getCollection("notes")).sort(
+    (a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf()
+  );
+  return posts.map((post, i) => {
+    const newer = posts[i - 1];
+    const older = posts[i + 1];
+    return {
+      params: { slug: post.slug },
+      props: {
+        post,
+        prev: older ? { slug: older.slug, title: older.data.title } : null,
+        next: newer ? { slug: newer.slug, title: newer.data.title } : null,
+      },
+    };
+  });
 }
-type Props = CollectionEntry<"notes">;
+type Props = {
+  post: CollectionEntry<"notes">;
+  prev: { slug: string; title: string } | null;
+  next: { slug: string; title: string } | null;
+};
 
-const post = Astro.props;
+const { post, prev, next } = Astro.props;
 const { Content } = await post.render();
+const minutes = readingTime(post.body);
 ---
 
-<BlogPost {...post.data}>
+<BlogPost {...post.data} readingTime={minutes} prev={prev} next={next}>
   <Content />
 </BlogPost>

--- a/src/pages/notes/index.astro
+++ b/src/pages/notes/index.astro
@@ -3,42 +3,48 @@ import BaseHead from "../../components/BaseHead.astro";
 import Header from "../../components/Header.astro";
 import Footer from "../../components/Footer.astro";
 import PostCard from "../../components/PostCard.astro";
-import { SITE_TITLE, SITE_DESCRIPTION } from "../../consts";
 import { getCollection } from "astro:content";
 
 const posts = (await getCollection("notes")).sort(
   (a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf()
 );
+const title = "Notes — Mario Yordanov";
+const description =
+  "Notes on web development, architecture, and whatever I'm thinking through.";
 ---
 
 <!doctype html>
 <html lang="en">
   <head>
-    <BaseHead title={SITE_TITLE} description={SITE_DESCRIPTION} />
+    <BaseHead title={title} description={description} />
+    <link rel="stylesheet" href="/pagefind/pagefind-ui.css" />
     <style>
       ul {
         display: flex;
-        flex-wrap: wrap;
-        gap: 2rem;
+        flex-direction: column;
+        gap: 1.5rem;
         list-style-type: none;
         margin: 0;
         padding: 0;
       }
-      ul li {
-        width: 100%;
-        text-decoration: none;
-      }
       .title {
-        padding: 1em 0;
+        padding: 1em 0 0.5em;
         line-height: 1;
       }
       .title h1 {
         margin: 0 0 0.5em 0;
       }
-      @media (max-width: 720px) {
-        ul {
-          gap: 0.5em;
-        }
+      .search {
+        margin-bottom: 2rem;
+      }
+      /* Pagefind UI theming */
+      #search {
+        --pagefind-ui-primary: var(--accent);
+        --pagefind-ui-text: var(--text-primary);
+        --pagefind-ui-background: var(--bg-primary);
+        --pagefind-ui-border: var(--border-color);
+        --pagefind-ui-font: "Roboto", sans-serif;
+        --pagefind-ui-border-radius: 8px;
       }
     </style>
   </head>
@@ -48,27 +54,53 @@ const posts = (await getCollection("notes")).sort(
       <section>
         <div class="title">
           <h1>Notes on...</h1>
-          <p><i>Quick thoughts on web development</i></p>
+          <p><i>Quick thoughts on web development, mostly for myself</i></p>
           <hr />
+        </div>
+        <div class="search">
+          <div id="search"></div>
         </div>
         <ul>
           {
             posts.map((post) => (
-              <>
-                <li>
-                  <PostCard
-                    pubDate={post.data.pubDate}
-                    title={post.data.title}
-                    description={post.data.description}
-                    slug={post.slug}
-                  />
-                </li>
-              </>
+              <li>
+                <PostCard
+                  pubDate={post.data.pubDate}
+                  title={post.data.title}
+                  description={post.data.description}
+                  slug={post.slug}
+                  tags={post.data.tags}
+                  status={post.data.status}
+                />
+              </li>
             ))
           }
         </ul>
       </section>
     </main>
     <Footer />
+    <script>
+      // Pagefind bundle is generated into /pagefind at build time and only
+      // exists on the built/preview site (not in bare `astro dev`).
+      window.addEventListener("DOMContentLoaded", () => {
+        const path = "/pagefind/pagefind-ui.js";
+        import(/* @vite-ignore */ path)
+          .then(({ PagefindUI }) => {
+            new PagefindUI({
+              element: "#search",
+              showSubResults: true,
+              showImages: false,
+              resetStyles: false,
+              translations: { placeholder: "Search notes..." },
+            });
+          })
+          .catch(() => {
+            const el = document.getElementById("search");
+            if (el)
+              el.innerHTML =
+                '<p style="color: rgb(var(--gray)); font-size: 0.9rem;">Search is available on the built site.</p>';
+          });
+      });
+    </script>
   </body>
 </html>

--- a/src/pages/rss.xml.js
+++ b/src/pages/rss.xml.js
@@ -3,13 +3,18 @@ import { getCollection } from "astro:content";
 import { SITE_TITLE, SITE_DESCRIPTION } from "../consts";
 
 export async function GET(context) {
-  const posts = await getCollection("notes");
+  const posts = (await getCollection("notes")).sort(
+    (a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf()
+  );
   return rss({
     title: SITE_TITLE,
     description: SITE_DESCRIPTION,
     site: context.site,
     items: posts.map((post) => ({
-      ...post.data,
+      title: post.data.title,
+      description: post.data.description,
+      pubDate: post.data.pubDate,
+      categories: post.data.tags,
       link: `/notes/${post.slug}/`,
     })),
   });

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -1,0 +1,82 @@
+---
+import BaseHead from "../../components/BaseHead.astro";
+import Header from "../../components/Header.astro";
+import Footer from "../../components/Footer.astro";
+import PostCard from "../../components/PostCard.astro";
+import { getCollection } from "astro:content";
+
+export async function getStaticPaths() {
+  const notes = await getCollection("notes");
+  const tags = [...new Set(notes.flatMap((n) => n.data.tags))];
+  return tags.map((tag) => ({
+    params: { tag },
+    props: {
+      tag,
+      notes: notes
+        .filter((n) => n.data.tags.includes(tag))
+        .sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf()),
+    },
+  }));
+}
+
+const { tag, notes } = Astro.props;
+const title = `#${tag} — Notes`;
+const description = `Notes tagged with #${tag}.`;
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <BaseHead title={title} description={description} />
+  </head>
+  <body>
+    <Header />
+    <main>
+      <section>
+        <div class="title">
+          <p class="crumb"><a href="/tags/">← All tags</a></p>
+          <h1>#{tag}</h1>
+          <p><i>{notes.length} note{notes.length === 1 ? "" : "s"}</i></p>
+          <hr />
+        </div>
+        <ul>
+          {
+            notes.map((post) => (
+              <li>
+                <PostCard
+                  pubDate={post.data.pubDate}
+                  title={post.data.title}
+                  description={post.data.description}
+                  slug={post.slug}
+                  tags={post.data.tags}
+                  status={post.data.status}
+                />
+              </li>
+            ))
+          }
+        </ul>
+      </section>
+    </main>
+    <Footer />
+    <style>
+      ul {
+        display: flex;
+        flex-direction: column;
+        gap: 1.5rem;
+        list-style: none;
+        margin: 0;
+        padding: 0;
+      }
+      .title {
+        padding: 1em 0;
+      }
+      .title h1 {
+        margin: 0.2em 0;
+      }
+      .crumb a {
+        color: rgb(var(--gray));
+        text-decoration: none;
+      }
+    </style>
+  </body>
+</html>

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -1,0 +1,79 @@
+---
+import BaseHead from "../../components/BaseHead.astro";
+import Header from "../../components/Header.astro";
+import Footer from "../../components/Footer.astro";
+import { getCollection } from "astro:content";
+
+const notes = await getCollection("notes");
+const counts = new Map<string, number>();
+for (const note of notes) {
+  for (const tag of note.data.tags) {
+    counts.set(tag, (counts.get(tag) ?? 0) + 1);
+  }
+}
+const tags = [...counts.entries()].sort((a, b) => b[1] - a[1]);
+
+const title = "Tags — Notes";
+const description = "Browse notes by topic.";
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <BaseHead title={title} description={description} />
+  </head>
+  <body>
+    <Header />
+    <main>
+      <section>
+        <div class="title">
+          <h1>Tags</h1>
+          <p><i>Browse notes by topic</i></p>
+          <hr />
+        </div>
+        <div class="cloud">
+          {
+            tags.map(([tag, count]) => (
+              <a href={`/tags/${tag}/`} class="tag">
+                #{tag} <span class="count">{count}</span>
+              </a>
+            ))
+          }
+        </div>
+      </section>
+    </main>
+    <Footer />
+    <style>
+      .title {
+        padding: 1em 0;
+      }
+      .cloud {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.6rem;
+      }
+      .tag {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.4em;
+        font-family: "Roboto", sans-serif;
+        font-size: 0.95rem;
+        padding: 0.5em 0.9em;
+        border: 1px solid var(--border-color);
+        border-radius: 999px;
+        text-decoration: none;
+        color: var(--text-primary);
+        background: var(--bg-secondary);
+        transition: 0.2s ease;
+      }
+      .tag:hover {
+        border-color: var(--accent);
+        color: var(--accent);
+      }
+      .count {
+        color: rgb(var(--gray));
+        font-size: 0.8rem;
+      }
+    </style>
+  </body>
+</html>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,8 +1,8 @@
 :root {
   --text-color: #fff;
   --bg-color: #0f172a;
-  --accent: #2337ff;
-  --accent-dark: #000d8a;
+  --accent: #0f766e;
+  --accent-dark: #115e59;
   --black: 15, 18, 25;
   --gray: 96, 115, 159;
   --gray-light: 229, 233, 240;
@@ -21,6 +21,7 @@
 }
 
 [data-theme="dark"] {
+  --accent: #2dd4bf;
   --bg-primary: #0f172a;
   --bg-secondary: rgba(34, 41, 57, 0.5);
   --text-primary: rgb(229, 233, 240);

--- a/src/utils/reading-time.ts
+++ b/src/utils/reading-time.ts
@@ -1,0 +1,11 @@
+/**
+ * Estimate reading time in minutes from raw markdown/text content.
+ */
+export function readingTime(content: string): number {
+  const words = content
+    .replace(/```[\s\S]*?```/g, " ") // drop code blocks
+    .replace(/[#>*_`~\-]/g, " ")
+    .split(/\s+/)
+    .filter(Boolean).length;
+  return Math.max(1, Math.round(words / 200));
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,5 +2,6 @@
   "extends": "astro/tsconfigs/base",
   "compilerOptions": {
     "strictNullChecks": true
-  }
+  },
+  "exclude": ["dist", "node_modules"]
 }


### PR DESCRIPTION
## Summary
Makes the notes site more useful as a personal thinking space while keeping the serif "essay" look. All changes build cleanly (`astro check` → 0 errors) and Pagefind indexes correctly.

### Structure & discovery
- **Tags taxonomy** — new `tags` frontmatter, `/tags` cloud, and per-tag pages (`/tags/[tag]`). Tags shown on cards and post headers. Backfilled tags on all existing notes.
- **Note status** — `seedling / growing / evergreen` badges to lean into the notes-to-self vibe.
- **Homepage** — restored a fixed "Recent notes" section (removed dead commented code + a stray `</div>`), so the landing page surfaces content.
- **Pagefind search** — client-side search on the Notes page, indexed as a `postbuild` step (works on GitHub Pages).

### Reading experience
- Reading time, prev/next navigation, and a "← Back to notes" link on posts.
- Copy-to-clipboard buttons on code blocks.
- Renders `heroImage` when present; shows `updatedDate`.

### Polish
- Fixed broken `PostCard` hover selectors; redesigned cards with hover lift.
- Improved RSS feed (sorted, tag categories) + linked in `<head>` and footer.
- Refined accent color for light/dark and tidied spacing/typography.
- Added a **Tags** link to the header nav; per-page titles/descriptions.

### Notes
- Search requires a production build to generate the `/pagefind` bundle (won't appear in bare `astro dev`); it degrades gracefully with a message.
- Initial tags/status were inferred per note and are easy to tweak.