### PR TITLE
feat: add bookshelf with reading status and reviews

### DIFF
--- a/src/components/BookCard.astro
+++ b/src/components/BookCard.astro
@@ -1,0 +1,155 @@
+---
+import FormattedDate from "./FormattedDate.astro";
+import BookStatus from "./BookStatus.astro";
+import StarRating from "./StarRating.astro";
+
+interface Props {
+  slug: string;
+  title: string;
+  author: string;
+  description: string;
+  status: "reading" | "want-to-read" | "read";
+  rating?: number;
+  finishedDate?: Date;
+  cover?: string;
+}
+
+const { slug, title, author, description, status, rating, finishedDate, cover } =
+  Astro.props;
+---
+
+<a href={`/bookshelf/${slug}/`} class="card" data-tilt>
+  <div class="cover" aria-hidden="true">
+    {cover ? (
+      <img src={cover} alt="" loading="lazy" />
+    ) : (
+      <span class="initial">{title[0]}</span>
+    )}
+  </div>
+  <div class="body">
+    <div class="meta">
+      <BookStatus status={status} />
+      {rating && <StarRating rating={rating} />}
+    </div>
+    <h2 class="title">{title}</h2>
+    <p class="author">by {author}</p>
+    <p class="description">{description}</p>
+    {finishedDate && (
+      <p class="finished">
+        Finished <FormattedDate date={finishedDate} />
+      </p>
+    )}
+  </div>
+</a>
+<style>
+  .card {
+    display: flex;
+    gap: 1.25rem;
+    border: 1px solid var(--border-color);
+    padding: 1.5rem;
+    border-radius: 0.75rem;
+    text-decoration: none;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.1s ease;
+    background: var(--bg-primary);
+    transform-style: preserve-3d;
+    will-change: transform;
+  }
+  .card:hover {
+    border-color: var(--accent);
+    box-shadow: 0 10px 30px rgba(var(--gray), 22%);
+  }
+  .cover {
+    flex-shrink: 0;
+    width: 84px;
+    height: 126px;
+    border-radius: 0.4rem;
+    overflow: hidden;
+    background: linear-gradient(135deg, var(--accent), var(--accent-dark));
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+  .cover img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    border-radius: 0;
+  }
+  .initial {
+    font-family: "Roboto", sans-serif;
+    font-weight: 700;
+    font-size: 2.5rem;
+    color: #fff;
+    user-select: none;
+  }
+  .body {
+    min-width: 0;
+  }
+  .meta {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+  }
+  .title {
+    margin: 0.4rem 0 0 0;
+    line-height: 1.15;
+    font-size: 1.35rem;
+  }
+  .card:hover .title {
+    color: var(--accent);
+  }
+  .author {
+    margin: 0.15rem 0 0 0;
+    color: var(--text-primary);
+    font-family: "Roboto", sans-serif;
+    font-size: 0.9rem;
+  }
+  .description {
+    color: rgb(var(--gray));
+    margin: 0.5rem 0 0 0;
+    font-size: 0.95rem;
+  }
+  .finished {
+    margin: 0.5rem 0 0 0;
+    color: rgb(var(--gray));
+    font-size: 0.8rem;
+  }
+  @media (max-width: 480px) {
+    .cover {
+      width: 64px;
+      height: 96px;
+    }
+    .card {
+      gap: 1rem;
+      padding: 1rem;
+    }
+  }
+</style>
+
+<script>
+  function initTilt() {
+    const reduce = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    const fine = window.matchMedia("(pointer: fine)").matches;
+    if (reduce || !fine) return;
+
+    const MAX = 6; // degrees
+    document.querySelectorAll<HTMLElement>("[data-tilt]").forEach((card) => {
+      if (card.dataset.tiltBound) return;
+      card.dataset.tiltBound = "true";
+
+      card.addEventListener("pointermove", (e) => {
+        const r = card.getBoundingClientRect();
+        const px = (e.clientX - r.left) / r.width - 0.5;
+        const py = (e.clientY - r.top) / r.height - 0.5;
+        card.style.transform = `perspective(700px) rotateY(${px * MAX}deg) rotateX(${-py * MAX}deg) translateY(-2px)`;
+      });
+      card.addEventListener("pointerleave", () => {
+        card.style.transform = "";
+      });
+    });
+  }
+
+  initTilt();
+  document.addEventListener("astro:page-load", initTilt);
+</script>

--- a/src/components/BookStatus.astro
+++ b/src/components/BookStatus.astro
@@ -1,0 +1,36 @@
+---
+interface Props {
+  status: "reading" | "want-to-read" | "read";
+}
+
+const { status } = Astro.props;
+
+const meta = {
+  reading: { label: "Reading", icon: "📖", hint: "Currently reading" },
+  "want-to-read": { label: "Want to read", icon: "🔖", hint: "On the to-read pile" },
+  read: { label: "Finished", icon: "✅", hint: "Read and finished" },
+} as const;
+
+const { label, icon, hint } = meta[status];
+---
+
+<span class:list={["status", status]} title={hint}>
+  <span aria-hidden="true">{icon}</span>{label}
+</span>
+
+<style>
+  .status {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35em;
+    font-family: "Roboto", sans-serif;
+    font-size: 0.75rem;
+    line-height: 1;
+    padding: 0.35em 0.6em;
+    border-radius: 999px;
+    color: rgb(var(--gray));
+    border: 1px solid var(--border-color);
+    background: var(--bg-secondary);
+    white-space: nowrap;
+  }
+</style>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -9,6 +9,7 @@ import ThemeToggle from "./ThemeToggle.astro";
       <HeaderLink href="/">Home</HeaderLink>
       <HeaderLink href="/playground">Playground</HeaderLink>
       <HeaderLink href="/notes">Notes</HeaderLink>
+      <HeaderLink href="/bookshelf">Bookshelf</HeaderLink>
       <ThemeToggle />
     </div>
   </nav>

--- a/src/components/StarRating.astro
+++ b/src/components/StarRating.astro
@@ -1,0 +1,36 @@
+---
+interface Props {
+  rating: number;
+}
+
+const { rating } = Astro.props;
+const stars = Array.from({ length: 5 }, (_, i) => i < rating);
+---
+
+<span class="stars" role="img" aria-label={`${rating} out of 5 stars`}>
+  {
+    stars.map((filled) => (
+      <span
+        aria-hidden="true"
+        class:list={["star", { filled }]}
+      >
+        {filled ? "★" : "☆"}
+      </span>
+    ))
+  }
+</span>
+
+<style>
+  .stars {
+    display: inline-flex;
+    gap: 0.1em;
+    font-size: 0.85rem;
+    line-height: 1;
+  }
+  .star {
+    color: rgb(var(--gray));
+  }
+  .star.filled {
+    color: var(--accent);
+  }
+</style>

--- a/src/content/books/children-of-ruin.md
+++ b/src/content/books/children-of-ruin.md
@@ -1,0 +1,9 @@
+---
+title: "Children of Ruin"
+author: "Adrian Tchaikovsky"
+description: "The sequel to Children of Time. Centuries after first contact with the spider kin, a human expedition follows a strange signal to a world terraformed by intelligent octopuses."
+addedDate: "Jul 1 2026"
+tags: ["sci-fi", "space opera"]
+status: "reading"
+link: "https://en.wikipedia.org/wiki/Children_of_Ruin_(novel)"
+---

--- a/src/content/books/children-of-time.md
+++ b/src/content/books/children-of-time.md
@@ -1,0 +1,15 @@
+---
+title: "Children of Time"
+author: "Adrian Tchaikovsky"
+description: "A generation-ship of human survivors stumbles onto a terraformed world where uplifted jumping spiders have quietly built a civilization of their own."
+addedDate: "Sep 10 2025"
+finishedDate: "Nov 20 2025"
+rating: 5
+tags: ["sci-fi", "space opera"]
+status: "read"
+link: "https://en.wikipedia.org/wiki/Children_of_Time_(novel)"
+---
+
+Uplifted spiders shouldn't be this compelling, and yet here we are. Tchaikovsky runs two timelines in parallel — the humans fleeing a dying Earth and the spiders slowly evolving intelligence on a world they were meant to inherit — and the real trick is that the spider chapters are the ones you want to get back to.
+
+The book is genuinely about perspective. The closest thing to a villain is a mind that physically cannot comprehend the others around it. It made me think a lot about how teams work: the ones that build a shared language succeed, and the ones that don't quietly fall apart. One of those books that reframes how you think about communication.

--- a/src/content/books/deep-work.md
+++ b/src/content/books/deep-work.md
@@ -1,0 +1,9 @@
+---
+title: "Deep Work"
+author: "Cal Newport"
+description: "A case for long, uninterrupted, cognitively demanding focus — and a practical plan for making room for it in a distracted world."
+addedDate: "Jun 15 2026"
+tags: ["productivity"]
+status: "want-to-read"
+link: "https://www.calnewport.com/books/deep-work/"
+---

--- a/src/content/books/dune.md
+++ b/src/content/books/dune.md
@@ -1,0 +1,9 @@
+---
+title: "Dune"
+author: "Frank Herbert"
+description: "The desert planet Arrakis, spice, politics, prophecy, and the weight of a legacy. On the list because everyone insists I must read it."
+addedDate: "Jun 20 2026"
+tags: ["sci-fi", "classic"]
+status: "want-to-read"
+link: "https://en.wikipedia.org/wiki/Dune_(novel)"
+---

--- a/src/content/books/project-hail-mary.md
+++ b/src/content/books/project-hail-mary.md
@@ -1,0 +1,15 @@
+---
+title: "Project Hail Mary"
+author: "Andy Weir"
+description: "A lone astronaut wakes up on a spaceship with no memory and a mission to save Earth from an extinction-level threat. Then he meets Rocky."
+addedDate: "Feb 10 2026"
+finishedDate: "Feb 10 2026"
+rating: 5
+tags: ["sci-fi", "hard sci-fi"]
+status: "read"
+link: "https://en.wikipedia.org/wiki/Project_Hail_Mary"
+---
+
+Everyone talks about Rocky, and they're right to. This is a book carried by a friendship — and one of your two protagonists is an alien with an entirely different biochemistry who communicates through musical notes and knock patterns. That it works this well is a masterclass in empathy-driven writing.
+
+The science is the plot, the way Weir does it: a problem, a clever solution, a new problem. It reads like one long, very good debugging session, which for me is the draw. The audiobook is famously great, but I read it on paper and it lands just fine.

--- a/src/content/books/the-martian.md
+++ b/src/content/books/the-martian.md
@@ -1,0 +1,15 @@
+---
+title: "The Martian"
+author: "Andy Weir"
+description: "Mark Watney, botanist and professional smartass, gets stranded on Mars and has to science his way back to Earth one problem at a time."
+addedDate: "Dec 5 2025"
+finishedDate: "Dec 5 2025"
+rating: 4
+tags: ["sci-fi", "hard sci-fi"]
+status: "read"
+link: "https://en.wikipedia.org/wiki/The_Martian_(Weir_novel)"
+---
+
+The spiritual ancestor of Project Hail Mary and the perfect "one problem at a time" book. Every chapter is basically a small engineering task with a deadline, and Watney's log entries keep it funny even when the stakes are fatal.
+
+A good reminder that most hard problems are just a chain of smaller ones — and that keeping a clean log of what you tried is half the battle.

--- a/src/content/books/the-pragmatic-programmer.md
+++ b/src/content/books/the-pragmatic-programmer.md
@@ -1,0 +1,15 @@
+---
+title: "The Pragmatic Programmer"
+author: "David Thomas & Andrew Hunt"
+description: "The classic. Two decades of collected advice for developers — DRY, orthogonality, deliberate programming — that somehow stays relevant."
+addedDate: "Aug 14 2025"
+finishedDate: "Aug 14 2025"
+rating: 4
+tags: ["engineering", "career"]
+status: "read"
+link: "https://pragprog.com/titles/tpp20/the-pragmatic-programmer-20th-anniversary-edition/"
+---
+
+I read this way later than I should have. Most of it is advice you've absorbed piecemeal over the years — DRY, orthogonality, "program deliberately" — but seeing it all collected and argued for is worth it. The "broken windows" and "boiling frogs" chapters alone justify the shelf space.
+
+The code examples show their age, but the mindset half is timeless. The takeaway that stuck with me: keep your tools sharp and document *why*, not just *what*.

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -17,4 +17,20 @@ const notes = defineCollection({
   }),
 });
 
-export const collections = { notes };
+const books = defineCollection({
+  type: "content",
+  schema: z.object({
+    title: z.string(),
+    author: z.string(),
+    description: z.string(),
+    cover: z.string().optional(),
+    addedDate: z.coerce.date(),
+    finishedDate: z.coerce.date().optional(),
+    rating: z.number().int().min(1).max(5).optional(),
+    tags: z.array(z.string()).default([]),
+    status: z.enum(["reading", "want-to-read", "read"]),
+    link: z.string().url().optional(),
+  }),
+});
+
+export const collections = { notes, books };

--- a/src/pages/bookshelf/[...slug].astro
+++ b/src/pages/bookshelf/[...slug].astro
@@ -1,0 +1,202 @@
+---
+import { type CollectionEntry, getCollection } from "astro:content";
+import BaseHead from "../../components/BaseHead.astro";
+import Header from "../../components/Header.astro";
+import Footer from "../../components/Footer.astro";
+import FormattedDate from "../../components/FormattedDate.astro";
+import BookStatus from "../../components/BookStatus.astro";
+import StarRating from "../../components/StarRating.astro";
+import Tag from "../../components/Tag.astro";
+
+export async function getStaticPaths() {
+  const books = await getCollection("books");
+  return books.map((book) => ({
+    params: { slug: book.slug },
+    props: { book },
+  }));
+}
+
+type Props = { book: CollectionEntry<"books"> };
+
+const { book } = Astro.props;
+const { Content } = await book.render();
+const {
+  title,
+  author,
+  description,
+  cover,
+  status,
+  rating,
+  finishedDate,
+  addedDate,
+  tags = [],
+  link,
+} = book.data;
+const pageTitle = `${title} — Bookshelf`;
+const hasNotes = book.body.trim().length > 0;
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <BaseHead title={pageTitle} description={description} image={cover} />
+  </head>
+  <body>
+    <Header />
+    <main>
+      <article>
+        <a href="/bookshelf/" class="back-link">← Back to bookshelf</a>
+        <header class="book-head">
+          <div class="cover" aria-hidden="true">
+            {cover ? (
+              <img src={cover} alt="" />
+            ) : (
+              <span class="initial">{title[0]}</span>
+            )}
+          </div>
+          <div class="head-body">
+            <div class="meta">
+              <BookStatus status={status} />
+              {rating && <StarRating rating={rating} />}
+            </div>
+            <h1 class="book-title">{title}</h1>
+            <p class="author">by {author}</p>
+            <p class="description">{description}</p>
+            <p class="shelf-date">
+              Added <FormattedDate date={addedDate} />
+              {finishedDate && (
+                <>
+                  {" · "}Finished <FormattedDate date={finishedDate} />
+                </>
+              )}
+            </p>
+            {
+              tags.length > 0 && (
+                <div class="tags">
+                  {tags.map((tag) => (
+                    <Tag tag={tag} interactive={false} />
+                  ))}
+                </div>
+              )
+            }
+            {link && (
+              <p class="buy-link">
+                <a href={link} target="_blank" rel="noopener noreferrer">
+                  Find this book →
+                </a>
+              </p>
+            )}
+          </div>
+        </header>
+        <hr />
+        {hasNotes ? (
+          <div class="prose">
+            <Content />
+          </div>
+        ) : (
+          <p class="no-notes">
+            <i>No review yet — it's on my shelf, and I'll write notes here when it's done.</i>
+          </p>
+        )}
+      </article>
+    </main>
+    <Footer />
+    <style>
+      .back-link {
+        display: inline-block;
+        margin-bottom: 1em;
+        color: rgb(var(--gray));
+        text-decoration: none;
+        font-family: "Roboto", sans-serif;
+        font-size: 0.9rem;
+      }
+      .back-link:hover {
+        color: var(--accent);
+      }
+      .book-head {
+        display: flex;
+        gap: 1.75rem;
+        align-items: flex-start;
+      }
+      .cover {
+        flex-shrink: 0;
+        width: 128px;
+        height: 192px;
+        border-radius: 0.5rem;
+        overflow: hidden;
+        background: linear-gradient(135deg, var(--accent), var(--accent-dark));
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+      .cover img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        border-radius: 0;
+      }
+      .initial {
+        font-family: "Roboto", sans-serif;
+        font-weight: 700;
+        font-size: 4rem;
+        color: #fff;
+        user-select: none;
+      }
+      .head-body {
+        min-width: 0;
+      }
+      .meta {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        flex-wrap: wrap;
+      }
+      .book-title {
+        margin: 0.4rem 0 0 0;
+        font-size: 2rem;
+      }
+      .author {
+        margin: 0.2rem 0 0 0;
+        color: var(--text-primary);
+        font-family: "Roboto", sans-serif;
+      }
+      .description {
+        margin: 0.75rem 0 0 0;
+        color: rgb(var(--gray));
+      }
+      .shelf-date {
+        margin: 0.75rem 0 0 0;
+        color: rgb(var(--gray));
+        font-family: "Roboto", sans-serif;
+        font-size: 0.85rem;
+      }
+      .tags {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.4rem;
+        margin-top: 0.75rem;
+      }
+      .buy-link {
+        margin: 0.75rem 0 0 0;
+      }
+      .no-notes {
+        color: rgb(var(--gray));
+      }
+      @media (max-width: 480px) {
+        .book-head {
+          flex-direction: column;
+          align-items: center;
+          text-align: center;
+        }
+        .head-body {
+          text-align: left;
+          width: 100%;
+        }
+        .meta,
+        .tags {
+          justify-content: center;
+        }
+      }
+    </style>
+  </body>
+</html>

--- a/src/pages/bookshelf/index.astro
+++ b/src/pages/bookshelf/index.astro
@@ -1,0 +1,119 @@
+---
+import BaseHead from "../../components/BaseHead.astro";
+import Header from "../../components/Header.astro";
+import Footer from "../../components/Footer.astro";
+import BookCard from "../../components/BookCard.astro";
+import { getCollection } from "astro:content";
+
+const books = await getCollection("books");
+
+const groupLabels = {
+  reading: { title: "Currently reading", blurb: "Books on the nightstand right now." },
+  "want-to-read": { title: "Want to read", blurb: "The to-read pile that keeps growing." },
+  read: { title: "Finished", blurb: "Read, rated, and occasionally reviewed." },
+} as const;
+
+const groups = (["reading", "want-to-read", "read"] as const)
+  .map((status) => {
+    const list = books
+      .filter((b) => b.data.status === status)
+      .sort((a, b) => {
+        const aKey = a.data.finishedDate?.valueOf() ?? a.data.addedDate.valueOf();
+        const bKey = b.data.finishedDate?.valueOf() ?? b.data.addedDate.valueOf();
+        return bKey - aKey;
+      });
+    return { status, ...groupLabels[status], books: list };
+  })
+  .filter((group) => group.books.length > 0);
+
+const title = "Bookshelf — Mario Yordanov";
+const description =
+  "Books I'm reading, want to read, and have finished — with the occasional review.";
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <BaseHead title={title} description={description} />
+  </head>
+  <body>
+    <Header />
+    <main>
+      <section>
+        <div class="title">
+          <h1>Bookshelf</h1>
+          <p><i>Books I'm reading, want to read, and have finished</i></p>
+          <hr />
+        </div>
+        {
+          groups.map((group) => (
+            <section class="group">
+              <header class="group-header">
+                <h2>{group.title}</h2>
+                <p class="count">{group.books.length}</p>
+              </header>
+              <p class="blurb">{group.blurb}</p>
+              <ul class="book-list">
+                {
+                  group.books.map((book) => (
+                    <li>
+                      <BookCard
+                        slug={book.slug}
+                        title={book.data.title}
+                        author={book.data.author}
+                        description={book.data.description}
+                        status={book.data.status}
+                        rating={book.data.rating}
+                        finishedDate={book.data.finishedDate}
+                        cover={book.data.cover}
+                      />
+                    </li>
+                  ))
+                }
+              </ul>
+            </section>
+          ))
+        }
+      </section>
+    </main>
+    <Footer />
+    <style>
+      .title {
+        padding: 1em 0;
+      }
+      .title h1 {
+        margin: 0 0 0.3em 0;
+      }
+      .group {
+        margin-top: 2.5rem;
+      }
+      .group-header {
+        display: flex;
+        align-items: baseline;
+        gap: 0.6rem;
+      }
+      .group-header h2 {
+        margin: 0;
+      }
+      .count {
+        margin: 0;
+        color: rgb(var(--gray));
+        font-family: "Roboto", sans-serif;
+        font-size: 0.85rem;
+      }
+      .blurb {
+        margin: 0.25rem 0 1rem 0;
+        color: rgb(var(--gray));
+        font-size: 0.9rem;
+      }
+      .book-list {
+        display: flex;
+        flex-direction: column;
+        gap: 1.5rem;
+        list-style-type: none;
+        margin: 0;
+        padding: 0;
+      }
+    </style>
+  </body>
+</html>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -67,7 +67,7 @@ const posts = (await getCollection("notes")).sort(
       <ul class="now-list">
         <li>Now Playing: <a href="https://youtu.be/BI9fgQY0d5I?si=PZkv0tGSW7dsr1tu" target="_blank">Rainbow Six Siege</a></li>
         <li>Now Listening: <a href="https://youtu.be/dr6IkPSrvbw?si=NgpaBAoJA-ehxfnL" target="_blank">Daliborovo Granje - Hainin</a></li>
-        <li>Now Reading: <a href="https://en.wikipedia.org/wiki/Children_of_Ruin" target="_blank">Children of Ruin by Adrian Tchaikovsky</a></li>
+        <li>Now Reading: <a href="/bookshelf/children-of-ruin/">Children of Ruin by Adrian Tchaikovsky</a></li>
       </ul>
       <section class="recent">
         <header class="recent-header">


### PR DESCRIPTION
## Summary
- New `books` content collection with status (`reading` / `want-to-read` / `read`), author, rating, finished date, cover, tags, and Markdown review body
- New `/bookshelf` page grouping books by status, with cover placeholders, star ratings, and tilt cards
- New `/bookshelf/[slug]/` detail pages for each book with metadata and review prose
- Nav link added; home "Now Reading" now points at the Children of Ruin book page
- 7 seeded books, 4 with short reviews

Built with plain Astro + scoped CSS, following existing site conventions.